### PR TITLE
High Isle and Volcanic Vents

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -104,7 +104,8 @@ function LibWorldEvents.Events.onWEActivate(eventCode, worldEventInstanceId)
     elseif
         LibWorldEvents.POI.HarrowStorms.onMap == true or
         LibWorldEvents.POI.Geyser.onMap == true or
-        LibWorldEvents.POI.Dolmen.onMap == true
+        LibWorldEvents.POI.Dolmen.onMap == true or
+        LibWorldEvents.POI.VolcanicVent.onMap == true
     then
         -- d("WEACtivate for poi")
 
@@ -143,7 +144,8 @@ function LibWorldEvents.Events.onWEDeactivate(eventCode, worldEventInstanceId)
     elseif
         LibWorldEvents.POI.HarrowStorms.onMap == true or
         LibWorldEvents.POI.Geyser.onMap == true or
-        LibWorldEvents.POI.Dolmen.onMap == true
+        LibWorldEvents.POI.Dolmen.onMap == true or
+        LibWorldEvents.POI.VolcanicVent.onMap == true
     then
         local poi = LibWorldEvents.POI.POIList:obtainLastActive()
 

--- a/LibWorldEvents.txt
+++ b/LibWorldEvents.txt
@@ -2,7 +2,7 @@
 ## Description: Lib to know World Events info
 ## Version: 2.1.1
 ## Author: bulton-fr
-## APIVersion: 101032
+## APIVersion: 101034
 ## IsLibrary: true
 
 lang\en.lua

--- a/LibWorldEvents.txt
+++ b/LibWorldEvents.txt
@@ -20,6 +20,7 @@ POI/POIStatus.lua
 POI/Dolmen.lua
 POI/Geyser.lua
 POI/HarrowStorms.lua
+POI/VolcanicVent.lua
 Events.lua
 Timer.lua
 FlyTimer.lua

--- a/POI/VolcanicVent.lua
+++ b/POI/VolcanicVent.lua
@@ -13,17 +13,25 @@ LibWorldEvents.POI.VolcanicVent.list = {
         mapName = "systres/u34_systreszone_base",
         list    = {
             title = {
-                cp = {},
+                cp = {
+                    [1] = GetString(SI_LIB_WORLD_EVENTS_CP_NORTH) .. " (" .. GetString(SI_LIB_WORLD_EVENTS_SUBZONE_HIGH_ISLE) .. ")",
+                    [2] = GetString(SI_LIB_WORLD_EVENTS_CP_WEST) .. " (" .. GetString(SI_LIB_WORLD_EVENTS_SUBZONE_HIGH_ISLE) .. ")",
+                    [3] = GetString(SI_LIB_WORLD_EVENTS_CP_EAST) .. " (" .. GetString(SI_LIB_WORLD_EVENTS_SUBZONE_HIGH_ISLE) .. ")",
+                    [4] = GetString(SI_LIB_WORLD_EVENTS_CP_SOUTH) .. " (" .. GetString(SI_LIB_WORLD_EVENTS_SUBZONE_HIGH_ISLE) .. ")",
+                    [5] = GetString(SI_LIB_WORLD_EVENTS_CP_EAST) .. " (" .. GetString(SI_LIB_WORLD_EVENTS_SUBZONE_AMENOS) .. ")",
+                    [6] = GetString(SI_LIB_WORLD_EVENTS_CP_CENTER) .. " (" .. GetString(SI_LIB_WORLD_EVENTS_SUBZONE_AMENOS) .. ")",
+                    [7] = GetString(SI_LIB_WORLD_EVENTS_CP_SOUTH) .. " (" .. GetString(SI_LIB_WORLD_EVENTS_SUBZONE_AMENOS) .. ")"
+                },
                 ln = {} --generated in generateList()
             },
             poiIDs = {
-                [1] = 2492, -- Sapphire Point
+                [1] = 2495, -- Garick's Rise
                 [2] = 2493, -- Navire
                 [3] = 2494, -- Feywatch Isle
-                [4] = 2495, -- Garick's Rise
-                [5] = 2496, -- Serpents Hollow
-                [6] = 2497, -- Haunted Coast
-                [7] = 2498, -- Flooded Coast
+                [4] = 2492, -- Sapphire Point
+                [5] = 2498, -- Flooded Coast
+                [6] = 2496, -- Serpents Hollow
+                [7] = 2497 -- Haunted Coast
             }
         }
     }
@@ -39,8 +47,6 @@ function LibWorldEvents.POI.VolcanicVent:generateList()
             local zoneIdx, poiIdx = GetPOIIndices(poiId)
             local poiTitle        = GetPOIInfo(zoneIdx, poiIdx)
             zoneData.list.title.ln[poiListIdx] = zo_strformat(poiTitle)
-            -- force cardinal point to be the POI title (removing "volcanic vent"), even if user has changed preferred label type
-            zoneData.list.title.cp[poiListIdx] = zo_strformat(poiTitle)
         end
     end
 

--- a/POI/VolcanicVent.lua
+++ b/POI/VolcanicVent.lua
@@ -1,0 +1,59 @@
+LibWorldEvents.POI.VolcanicVent = {}
+
+-- @var bool onMap To know if the user is on the map where the volcanicVents can happen
+LibWorldEvents.POI.VolcanicVent.onMap = false
+
+-- @var bool isGenerated To know if the list has been generated or not
+LibWorldEvents.POI.VolcanicVent.isGenerated = false
+
+-- @var table List of all zone with volcanicVents world events
+LibWorldEvents.POI.VolcanicVent.list = {
+    { -- High Isle
+        zoneId  = 1318,
+        mapName = "systres/u34_systreszone_base",
+        list    = {
+            title = {
+                cp = {},
+                ln = {} --generated in generateList()
+            },
+            poiIDs = {
+                [1] = 2492, -- Sapphire Point
+                [2] = 2493, -- Navire
+                [3] = 2494, -- Feywatch Isle
+                [4] = 2495, -- Garick's Rise
+                [5] = 2496, -- Serpents Hollow
+                [6] = 2497, -- Haunted Coast
+                [7] = 2498, -- Flooded Coast
+            }
+        }
+    }
+}
+
+--[[
+-- Obtain and add the location name of all POI to the list
+-- To always have an updated value for the current language, I prefer not to save it myself
+--]]
+function LibWorldEvents.POI.VolcanicVent:generateList()
+    for listIdx, zoneData in ipairs(self.list) do
+        for poiListIdx, poiId in ipairs(zoneData.list.poiIDs) do
+            local zoneIdx, poiIdx = GetPOIIndices(poiId)
+            local poiTitle        = GetPOIInfo(zoneIdx, poiIdx)
+            zoneData.list.title.ln[poiListIdx] = zo_strformat(poiTitle)
+            -- force cardinal point to be the POI title (removing "volcanic vent"), even if user has changed preferred label type
+            zoneData.list.title.cp[poiListIdx] = zo_strformat(poiTitle):gsub(" Volcanic Vent","")
+        end
+    end
+
+    self.isGenerated = true
+end
+
+--[[
+-- To obtain the zone's list where a volcanicVents world event can happen
+--]]
+function LibWorldEvents.POI.VolcanicVent:obtainList()
+    if self.isGenerated == false then
+        self:generateList()
+    end
+
+    return self.list
+end

--- a/POI/VolcanicVent.lua
+++ b/POI/VolcanicVent.lua
@@ -40,7 +40,7 @@ function LibWorldEvents.POI.VolcanicVent:generateList()
             local poiTitle        = GetPOIInfo(zoneIdx, poiIdx)
             zoneData.list.title.ln[poiListIdx] = zo_strformat(poiTitle)
             -- force cardinal point to be the POI title (removing "volcanic vent"), even if user has changed preferred label type
-            zoneData.list.title.cp[poiListIdx] = zo_strformat(poiTitle):gsub(" Volcanic Vent","")
+            zoneData.list.title.cp[poiListIdx] = zo_strformat(poiTitle)
         end
     end
 

--- a/Zone.lua
+++ b/Zone.lua
@@ -6,6 +6,7 @@ LibWorldEvents.Zone.WORLD_EVENT_TYPE = {
     HARROWSTORM = "harrowstorm",
     GEYSER      = "geyser",
     DOLMEN      = "dolmen",
+    VOLCANIC_VENT = "volcanicvent",
     -- OBLIVON_PORTAL = "oblivon portal" -- Not plugged yet
 }
 
@@ -57,6 +58,7 @@ function LibWorldEvents.Zone:resetZoneData()
     LibWorldEvents.POI.HarrowStorms.onMap = false
     LibWorldEvents.POI.Geyser.onMap       = false
     LibWorldEvents.POI.Dolmen.onMap       = false
+    LibWorldEvents.POI.VolcanicVent.onMap = false
 end
 
 --[[
@@ -71,11 +73,13 @@ function LibWorldEvents.Zone:checkWorldEvent(currentZoneId)
     local harrowstormZoneList = LibWorldEvents.POI.HarrowStorms:obtainList()
     local geyserZoneList      = LibWorldEvents.POI.Geyser:obtainList()
     local dolmenZoneList      = LibWorldEvents.POI.Dolmen:obtainList()
+    local volcanicVentZoneList = LibWorldEvents.POI.VolcanicVent:obtainList()
 
     self:checkWorldEventForType(currentZoneId, self.WORLD_EVENT_TYPE.DRAGON, dragonsZoneList)
     self:checkWorldEventForType(currentZoneId, self.WORLD_EVENT_TYPE.HARROWSTORM, harrowstormZoneList)
     self:checkWorldEventForType(currentZoneId, self.WORLD_EVENT_TYPE.GEYSER, geyserZoneList)
     self:checkWorldEventForType(currentZoneId, self.WORLD_EVENT_TYPE.DOLMEN, dolmenZoneList)
+    self:checkWorldEventForType(currentZoneId, self.WORLD_EVENT_TYPE.VOLCANIC_VENT, volcanicVentZoneList)
 
     -- If we are in a dungeon/delve/battleground or in an house : no world event.
     if IsUnitInDungeon("player") or GetCurrentZoneHouseId() ~= 0 then
@@ -134,12 +138,14 @@ function LibWorldEvents.Zone:initWorldEvent()
             LibWorldEvents.POI.Geyser.onMap = true
         elseif self.worldEventMapType == self.WORLD_EVENT_TYPE.DOLMEN then
             LibWorldEvents.POI.Dolmen.onMap = true
+        elseif self.worldEventMapType == self.WORLD_EVENT_TYPE.VOLCANIC_VENT then
+            LibWorldEvents.POI.VolcanicVent.onMap = true
         else
             -- d("unknown event")
             return
         end
 
-        LibWorldEvents.POI.POIList:update()
+            LibWorldEvents.POI.POIList:update()
         LibWorldEvents.POI.POIStatus:checkAllPOI()
     end
 end

--- a/lang/de.lua
+++ b/lang/de.lua
@@ -9,11 +9,15 @@ ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_SOUTH",      "Süden")
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_SOUTH_EAST", "Südosten")
 --ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_SOUTH_CENTER", "South Center")
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_SOUTH_WEST", "Südwesten")
--- ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_WEST",         "West")
--- ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_EAST",         "East")
--- ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER",       "Center")
+ ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_WEST",         "Westen")
+ ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_EAST",         "Osten")
+ ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER",       "Mitte")
 -- ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER_EAST",  "Center East")
 -- ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER_WEST",  "Center West")
+
+-- SubZone Names
+ZO_CreateStringId("SI_LIB_WORLD_EVENTS_SUBZONE_HIGH_ISLE", "Hochinsel")
+ZO_CreateStringId("SI_LIB_WORLD_EVENTS_SUBZONE_AMENOS",    "Amenos")
 
 -- Location names
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_LN_PROWLS_EDGE", "Rand der Jagd") -- North

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -15,6 +15,10 @@ ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER",       "Center")
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER_EAST",  "Center East")
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER_WEST",  "Center West")
 
+-- SubZone Names
+ZO_CreateStringId("SI_LIB_WORLD_EVENTS_SUBZONE_HIGH_ISLE", "High Isle")
+ZO_CreateStringId("SI_LIB_WORLD_EVENTS_SUBZONE_AMENOS",    "Amenos")
+
 -- Location names
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_LN_PROWLS_EDGE", "Prowl's Edge") -- North
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_LN_SANDBLOWN",   "Sandblown") -- South-East

--- a/lang/fr.lua
+++ b/lang/fr.lua
@@ -15,6 +15,10 @@ ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER",       "Centre")
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER_EAST",  "Centre-Est")
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_CP_CENTER_WEST",  "Centre-Ouest")
 
+-- SubZone Names
+ZO_CreateStringId("SI_LIB_WORLD_EVENTS_SUBZONE_HIGH_ISLE", "Île-Haute")
+ZO_CreateStringId("SI_LIB_WORLD_EVENTS_SUBZONE_AMENOS",    "Amenos")
+
 -- Location names
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_LN_PROWLS_EDGE", "Bord de Traque") -- North
 ZO_CreateStringId("SI_LIB_WORLD_EVENTS_LN_SANDBLOWN",   "Balayée par les sables") -- South-East

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ There are loaded in order :
 * POI/Dolmen.lua
 * POI/Geyser.lua
 * POI/HarrowStorms.lua
+* POI/VolcanicVent.lua
 * Events.lua
 * Timer.lua
 * FlyTimer.lua
@@ -460,6 +461,22 @@ Methods :
 
 * `LibWorldEvents.POI.HarrowStorms:generateList` : Obtain and add the location name of all POI to the list
 * `LibWorldEvents.POI.HarrowStorms:obtainList` : To obtain the zone's list where a harrowStorms world event can happen
+
+### POI/VolcanicVent.lua
+
+Table : `LibWorldEvents.POI.VolcanicVent`
+
+Contains all data about zone where volcanic vents are present
+
+Property :
+
+* `onMap` : To know if the user is on a map where volcanic vents world event can happen
+* `isGenerated` : To know if the list has been generated or not
+* `list` : List of all zone with volcanic vents world events
+
+Methods :
+* `LibWorldEvents.POI.VolcanicVent:generateList` : Obtain and add the location name of all POI to the list
+* `LibWorldEvents.POI.VolcanicVent:obtainList` : To obtain the zone's list where a volcanic vents world event can happen
 
 ### Events.lua
 


### PR DESCRIPTION
- Adds support for Volcanic Vents in High Isle.
- APIVersion bumped to `101034`

**NOTE**:
Due to the number of POIs and the fact they are spread between two islands, I decided to force the `zoneData.list.title.cp` values to be `poiTitle` just like `zoneData.list.title.ln`. I was having trouble figuring out how the cardinal points would be effective in this zone.
You have GitHub permissions on my fork/branch to make edits if you believe this was an incorrect decision.